### PR TITLE
refactor: make process-file-updates idempotent

### DIFF
--- a/tasks/internal/process-file-updates-task/README.md
+++ b/tasks/internal/process-file-updates-task/README.md
@@ -17,6 +17,9 @@ replacements to a yaml file that already exists. It will attempt to create a Mer
 | internalRequestPipelineRunName | name of the PipelineRun that called this task                                                                                                                                            | No       | -                                        |
 
 
+## Changes in 1.1.0
+* Use git diff branch1 branch2 to do comparation for idempotent 
+
 ## Changes in 1.0.1
 * Remove extra characters in the diff result
 

--- a/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
+++ b/tasks/internal/process-file-updates-task/process-file-updates-task.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: process-file-updates-task
   labels:
-    app.kubernetes.io/version: "1.0.1"
+    app.kubernetes.io/version: "1.1.0"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: release
@@ -251,27 +251,10 @@ spec:
         fi
 
         echo -e "\n*** START LOCAL CHANGES ***\n"
-        echo -e "\n*** Result from git diff ***\n"
-        # compare the differences between the working directory and the staging area 
-        git diff | tee "${TEMP}"/tempMRFile.diff
+        git diff
+        echo -e "\n*** END LOCAL CHANGES ***\n"
 
-        echo -e "\n*** Result from git diff --cache ***\n"
-        # compare the differences between the staging area and the latest commit
-        git diff --cached | tee "${TEMP}"/tempMRFile-cached.diff
-
-        if [[ -s "${TEMP}"/tempMRFile.diff ]]; then
-            # replacements exist 
-            # It's to deal with the lines like "@@ -N1,N2 +N3,N4 @@", 
-            # but it's possible to meet a line like "@@ -4,7 +4,7 @@ $schema: /app/app-settings.yml".
-            awk '/^@@/ {match($0, /@@ ([^@]+) @@/, arr); print arr[1]}' "${TEMP}"/tempMRFile.diff |\
-               tee "${TEMP}"/lineFile
-        elif [[ ! -s "${TEMP}"/tempMRFile-cached.diff ]]; then
-           # only seed exists and the file with the same content is there already 
-           echo "the seeding file already exists" \
-               | tee -a "$(results.fileUpdatesInfo.path)"
-           echo -n "Success" |tee "$(results.fileUpdatesState.path)"
-           exit 0
-        fi
+        curBranch=$(git branch --show-current)
 
         # Get all MRs by paginating through results
         page=1
@@ -279,7 +262,7 @@ spec:
         while true; do
             mrPage=$(glab mr list -R "${UPSTREAM_REPO}" --search "Konflux release" \
                 --per-page 100 --page $page | grep "^!" || true)
-            # add "$mrPagei" == '' check for unit testing
+            # add "$mrPage" == '' check for unit testing
             if [ -z "$mrPage" ] || [ "$mrPage" == '' ] ; then
                 break
             fi
@@ -290,41 +273,14 @@ spec:
         # Remove trailing newline
         openMRList=$(echo "$openMRList" | sed '/^$/d')
 
-        if [ -n "$openMRList" ]; then        
+        if [ -n "$openMRList" ]; then
             while IFS= read -r oneItem; do
                 mrNum=$(echo "$oneItem" | cut -f1 | tr -d '!')
-                foundMR=false
-                glab mr diff "${mrNum}" --repo "${UPSTREAM_REPO}" > "${TEMP}"/oneMR.diff 
 
-                if [[ ! -s "${TEMP}"/lineFile ]]; then
-                    # only seed exists and no replacements  
-                    grep '^[+][^+]' "${TEMP}"/oneMR.diff | sed -E 's/^[+]//' | tee "${TEMP}/mrFile"
+                git fetch origin merge-requests/"$mrNum"/head:mr_"$mrNum"
 
-                    # compare if the contents and the updated file names are the same 
-                    if  diff -q "${TEMP}"/mrFile "${targetFile}" > /dev/null; then
-                        grep "^diff --git" "${TEMP}"/oneMR.diff | tee "${TEMP}"/tmpFile
-                        while read -r line ; do
-                            changedFileName=$(echo "$line" | awk '{sub(/^b\//, "", $NF); print $NF}')
-                            if [[ "${changedFileName}" != "${targetFile}" ]]; then
-                                continue
-                            fi
-                            foundMR=true
-                            break
-                        done < "${TEMP}"/tmpFile
-                    fi
-                else
-                    # replacements exist
-                    grep '^[-+@]' "${TEMP}"/oneMR.diff | sed -E 's/^[@]//; s/@@.*//' | tee "${TEMP}/mrFile"
-                    # remove "a/" in  "--- a/dir/file" and "b/" in "+++ b/dir/file" 
-                    grep '^[-+@]' "${TEMP}"/tempMRFile.diff | sed -E 's/^[@]//; s/@@.*//' | \
-                        sed -E 's/^(---|\+\+\+) [ab]\//\1 /' | tee "${TEMP}/tmpFile"
-                    if diff -q "${TEMP}"/mrFile "${TEMP}"/tmpFile > /dev/null; then
-                        foundMR=true
-                    fi
-                fi
-                # if all the lines are matched, the MR is the same one
-                # it should exit 0 if the same MR exists 
-                if [[ "$foundMR" == true ]]; then
+                # it should exit 0 if the same MR exists
+                if git diff "$curBranch" mr_"$mrNum" > /dev/null; then
                     echo "there is an existing MR with the same updates in the repo"
                     echo "{\"merge_request\":\"${UPSTREAM_REPO}/-/merge_requests/${mrNum}\"}" \
                         | tee -a "$(results.fileUpdatesInfo.path)" 
@@ -333,7 +289,6 @@ spec:
                 fi
             done <<< "$openMRList"
         fi
-        echo -e "\n*** END LOCAL CHANGES ***\n"
 
         WORKING_BRANCH=$(uuidgen |awk '{print substr($1, 1, 8)}')
         git_commit_and_push --branch "$WORKING_BRANCH" --message "fileUpdates changes"

--- a/tasks/internal/process-file-updates-task/tests/mocks.sh
+++ b/tasks/internal/process-file-updates-task/tests/mocks.sh
@@ -28,18 +28,21 @@ function git() {
   if [[ "$*" == "config"* ]]; then
     /usr/bin/git "$@"
   fi
-  if [[ "$*" == "diff"* ]]; then
+  if [[ "$*" == "diff" ]]; then
     /usr/bin/git "$@"
+  fi
+  if [[ "$*" == "diff"* ]]; then
+    echo '' 
   fi
 }
 
 function glab() {
   if [[ "$*" == *"mr create"* ]]; then
     gitRepo=$(echo "$*" | cut -f5 -d/ | cut -f1 -d.)
-    echo "/merge_request/1"
+    echo "https://some.gitlab/test/one-update.git/-/merge_request/1"
   elif [[ "$*" == *"mr list"* ]]; then
-    if [[ "$*" == *"page 1" ]]; then
-      echo '!1'
+    if [[ "$*" == *"page 1" ]] && [[ "${gitRepo}" == "replace-idempotent" ]]; then
+      	echo '!1'
     else
       echo ''
     fi

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-combo.yaml
@@ -93,7 +93,8 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+                  "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements-idempotent.yaml
@@ -92,10 +92,13 @@ spec:
               #!/usr/bin/env bash
               set -eux
   
+              echo "Test that status is Success"
+              test "$(params.fileUpdatesState)" == "Success"
+
               cd "$(params.tempDir)/replace-idempotent"
               commits=$(git log --oneline | wc -l)
-
-              echo "Test no more commit created except the one in setup step"
+              
+              echo "no more commit created except the one in setup step"
               test "${commits}" == "1"
               rm -rf "$(params.tempDir)"
 

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-replacements.yaml
@@ -93,7 +93,8 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+                  "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)

--- a/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
+++ b/tasks/internal/process-file-updates-task/tests/test-process-file-updates-seed.yaml
@@ -81,7 +81,8 @@ spec:
               set -eux
 
               echo Test that merge_request can be parsed
-              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == "/merge_request/1"
+              test "$(jq -r .merge_request <<< "$(params.fileUpdatesInfo)")" == \
+                  "https://some.gitlab/test/one-update.git/-/merge_request/1"
 
               cd "$(params.tempDir)/one-update"
               commits=$(git log --oneline | wc -l)


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

Change to use `git diff branch1 branch2` to do comparation for idempotent

## Describe your changes

## Relevant Jira

## Checklist before requesting a review
- [ ] I have marked as draft or added `do not merge` label if there's a dependency PR
  - If you want reviews on your draft PR, you can add reviewers or add the `release-service-maintainers` handle if you are unsure who to tag
- [ ] My commit message includes `Signed-off-by: My name <email>`
- [ ] I have bumped the task/pipeline version string and updated changelog in the relevant README
- [ ] I read CONTRIBUTING.MD and [commit formatting](CONTRIBUTING.md#commit-message-formatting-and-standards)

